### PR TITLE
Refactor heredoc handling and expand functionality; update function s…

### DIFF
--- a/exec/exec_herdoc.c
+++ b/exec/exec_herdoc.c
@@ -6,14 +6,14 @@
 /*   By: eaqrabaw <eaqrabaw@student.42amman.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/22 00:29:25 by eaqrabaw          #+#    #+#             */
-/*   Updated: 2025/04/22 00:45:19 by eaqrabaw         ###   ########.fr       */
+/*   Updated: 2025/04/23 06:18:03 by eaqrabaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 static pid_t	fork_and_exec_heredoc(t_ast *node,
-					int prev_fd, t_minishell *data)
+	int prev_fd, t_minishell *data)
 {
 	pid_t	pid;
 	t_ast	*cmd;
@@ -37,8 +37,7 @@ static pid_t	fork_and_exec_heredoc(t_ast *node,
 	return (pid);
 }
 
-int		handle_heredoc_node(t_ast *node,
-			int prev_fd, t_minishell *data)
+int	handle_heredoc_node(t_ast *node, int prev_fd, t_minishell *data)
 {
 	pid_t	pid;
 	int		status;

--- a/exec/read.c
+++ b/exec/read.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   read.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: malrifai <malrifai@student.42.fr>          +#+  +:+       +#+        */
+/*   By: eaqrabaw <eaqrabaw@student.42amman.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/07 06:46:53 by eaqrabaw          #+#    #+#             */
-/*   Updated: 2025/04/22 19:33:11 by malrifai         ###   ########.fr       */
+/*   Updated: 2025/04/23 06:30:53 by eaqrabaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,7 +70,7 @@ void	ft_process_input(t_minishell *data, char *input)
 			expand_tokens(head, data->last_exit_status, data->env);
 			expand_wildcards(data->tokens);
 			data->ast_root = parse_ast(&head);
-			collect_heredocs(data->ast_root);
+			collect_heredocs(data->ast_root, data);
 		}
 	}
 }

--- a/expander/expand.c
+++ b/expander/expand.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expand.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: malrifai <malrifai@student.42.fr>          +#+  +:+       +#+        */
+/*   By: eaqrabaw <eaqrabaw@student.42amman.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/10 14:50:31 by malrifai          #+#    #+#             */
-/*   Updated: 2025/04/20 22:01:38 by malrifai         ###   ########.fr       */
+/*   Updated: 2025/04/23 06:14:31 by eaqrabaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -140,4 +140,25 @@ void expand_wildcards(t_token *tokens)
 		}
 		cur = cur->next;
 	}
+}
+
+char	*expand_line(char *line, t_minishell *data)
+{
+	char	*tilde_expanded;
+	char	*vars_expanded;
+	char	*final;
+
+	if (!line)
+		return (NULL);
+	tilde_expanded = expand_tilde(line);
+	if (!tilde_expanded)
+		return (NULL);
+	vars_expanded = expand_variables(tilde_expanded,
+			data->last_exit_status, data->env);
+	free(tilde_expanded);
+	if (!vars_expanded)
+		return (NULL);
+	final = remove_quotes(vars_expanded);
+	free(vars_expanded);
+	return (final);
 }

--- a/herdoc/herdoc_handler.c
+++ b/herdoc/herdoc_handler.c
@@ -6,54 +6,68 @@
 /*   By: eaqrabaw <eaqrabaw@student.42amman.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 06:38:24 by eaqrabaw          #+#    #+#             */
-/*   Updated: 2025/04/22 00:08:44 by eaqrabaw         ###   ########.fr       */
+/*   Updated: 2025/04/23 06:31:34 by eaqrabaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static int herdoc_failed(int pipefd[2])
+static void	print_heredoc_eof_warning(char *delimiter)
 {
-    close(pipefd[0]);
-    close(pipefd[1]);
-    return (HEREDOC_INTERRUPTED);
+	write(2, "minishell: warning: heredoc delimited by EOF (wanted '", 55);
+	write(2, delimiter, ft_strlen(delimiter));
+	write(2, "')\n", 3);
 }
 
-static int process_heredoc(t_ast *node)
+static int	heredoc_failed(int pipefd[2])
 {
-    char *line;
-
-    if (pipe(node->heredoc_pipe) == -1)
-        return (herdoc_failed(node->heredoc_pipe));
-    while ((line = readline("> ")))
-    {
-        if (ft_strcmp(line, node->file) == 0)
-        {
-            free(line);
-            break;
-        }
-        write(node->heredoc_pipe[1], line, ft_strlen(line));
-        write(node->heredoc_pipe[1], "\n", 1);
-        free(line);
-    }
-    if (!line)
-        return (herdoc_failed(node->heredoc_pipe));
-    close(node->heredoc_pipe[1]);
-    return (0);
+	close(pipefd[0]);
+	close(pipefd[1]);
+	return (HEREDOC_INTERRUPTED);
 }
 
-void collect_heredocs(t_ast *node)
+static int	process_heredoc(t_ast *node, t_minishell *data)
 {
-    if (!node)
-        return;
-        
-    collect_heredocs(node->left);
-    collect_heredocs(node->right);
-    if (node->type == NODE_HEREDOC)
-    {
-        if (process_heredoc(node) != 0)
-        {
-            return;
-        }
-    }
+	char	*line;
+
+	if (pipe(node->heredoc_pipe) == -1)
+		return (heredoc_failed(node->heredoc_pipe));
+	while ((line = readline("> ")))
+	{
+		if (ft_strcmp(line, node->file) == 0)
+		{
+			free(line);
+			break;
+		}
+		if (node->heredoc_expand)
+			line = expand_line(line, data);
+		write(node->heredoc_pipe[1], line, ft_strlen(line));
+		write(node->heredoc_pipe[1], "\n", 1);
+		free(line);
+	}
+	if (!line)
+	{
+        print_heredoc_eof_warning(node->file);
+		return (heredoc_failed(node->heredoc_pipe));
+	}
+	close(node->heredoc_pipe[1]);
+	free(node->file);
+	node->file = NULL;
+	return (0);
+}
+
+void	collect_heredocs(t_ast *node, t_minishell *data)
+{
+	if (!node)
+		return;
+	collect_heredocs(node->left, data);
+	collect_heredocs(node->right, data);
+	if (node->type == NODE_HEREDOC)
+	{
+		if (process_heredoc(node, data) != 0)
+		{
+			data->last_exit_status = 130;
+			return ;
+		}
+	}
 }

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: malrifai <malrifai@student.42.fr>          +#+  +:+       +#+        */
+/*   By: eaqrabaw <eaqrabaw@student.42amman.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/03 10:13:43 by eaqrabaw          #+#    #+#             */
-/*   Updated: 2025/04/22 19:32:49 by malrifai         ###   ########.fr       */
+/*   Updated: 2025/04/23 06:30:35 by eaqrabaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,6 +63,7 @@ typedef struct s_ast
 	char			**args;
 	char			*file;
 	int 			heredoc_pipe[2];
+	int				heredoc_expand;
 	struct s_ast	*left;
 	struct s_ast	*right;
 }	t_ast;
@@ -140,6 +141,7 @@ void 				delete_next_token(t_token *prev_token);
 t_token				*tokenizer(char *input);
 
 //expander/expand.c
+char				*expand_line(char *line, t_minishell *data);
 char				*expand_tilde(char *token);
 char				*remove_quotes(char *input);
 void				expand_tokens(t_token *tokens,
@@ -241,7 +243,8 @@ int					handle_redirection_node(t_ast *node,
 						int prev_fd, t_minishell *data);
 
 // herdoc/herdoc_handler.c
-void 				collect_heredocs(t_ast *node);
+
+void				collect_heredocs(t_ast *node, t_minishell *data);
 
 // syntax/syntax_check.c
 int					validate_token_sequence(t_token *tokens);

--- a/tokenizing/cmd_utils.c
+++ b/tokenizing/cmd_utils.c
@@ -6,7 +6,7 @@
 /*   By: eaqrabaw <eaqrabaw@student.42amman.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/08 14:07:09 by malrifai          #+#    #+#             */
-/*   Updated: 2025/04/21 21:41:13 by eaqrabaw         ###   ########.fr       */
+/*   Updated: 2025/04/23 06:29:12 by eaqrabaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,34 +73,54 @@ t_ast	*new_ast_cmd(void)
 // 	node->args = new_args;
 // }
 
+static void	handle_heredoc_info(t_ast *redir_node, char *raw)
+{
+	if ((raw[0] == '\'' && raw[ft_strlen(raw) - 1] == '\'')
+		|| (raw[0] == '"' && raw[ft_strlen(raw) - 1] == '"'))
+	{
+		redir_node->heredoc_expand = 0;
+		redir_node->file = ft_substr(raw, 1, ft_strlen(raw) - 2);
+	}
+	else
+	{
+		redir_node->heredoc_expand = 1;
+		redir_node->file = ft_strdup(raw);
+	}
+}
+
 t_ast	*handle_redirection(t_ast *cmd_node, t_token *token)
 {
 	t_ast	*redir_node;
+	char	*raw;
 
 	if (!cmd_node || !token || !token->next)
 		return (NULL);
 	redir_node = malloc(sizeof(t_ast));
 	if (!redir_node)
 		return (NULL);
-	redir_node->file = ft_strdup(token->next->value);
-	if (!redir_node->file)
-	{
-		free(redir_node);
-		return (NULL);
-	}
+	raw = token->next->value;
 	redir_node->left = cmd_node;
 	redir_node->right = NULL;
 	redir_node->args = NULL;
-	if (token->type == REDIR_IN)
-		redir_node->type = NODE_REDIR_IN;
-	else if (token->type == REDIR_OUT)
-		redir_node->type = NODE_REDIR_OUT;
-	else if (token->type == APPEND)
-		redir_node->type = NODE_APPEND;
-	else if (token->type == HEREDOC)
+	if (token->type == HEREDOC)
+	{
 		redir_node->type = NODE_HEREDOC;
+		handle_heredoc_info(redir_node, raw);
+	}
+	else
+	{
+		redir_node->file = ft_strdup(raw);
+		redir_node->heredoc_expand = 0;
+		if (token->type == REDIR_IN)
+			redir_node->type = NODE_REDIR_IN;
+		else if (token->type == REDIR_OUT)
+			redir_node->type = NODE_REDIR_OUT;
+		else if (token->type == APPEND)
+			redir_node->type = NODE_APPEND;
+	}
 	return (redir_node);
 }
+
 
 void	add_argument(t_ast *node, char *arg)
 {


### PR DESCRIPTION
…ignatures and add heredoc expansion logic
Handled most herdoc cases 
NEW PROBLEMS !!!!!
*********************************
-> IF THE COMMAND HAS MULTI SPACES BEFORE THE DELIMITER IT WILL DOUBLE FREE IDK WHY !
THE ERROR IS :
free(): double free detected in tcache 2
Aborted (core dumped)

-> IF THE COMMAND USED THE PIPE
minishell> cat << A | cat << B
> aa
> A
> dd
> B
cat: write error: Bad file descriptor
